### PR TITLE
fix(decoder): fix multiPartBuffer

### DIFF
--- a/src/ais-decoder.ts
+++ b/src/ais-decoder.ts
@@ -64,6 +64,8 @@ class AisDecoder extends Transform {
         multiPartSentence => multiPartSentence.payload
       );
       this.decodePayload(payloads.join(''), sentence.channel);
+
+      this.multiPartBuffer.length = 0;
     }
   }
 

--- a/src/ais-decoder.ts
+++ b/src/ais-decoder.ts
@@ -60,6 +60,11 @@ class AisDecoder extends Transform {
     this.multiPartBuffer.push(sentence);
 
     if (sentence.isLastPart()) {
+      if (this.multiPartBuffer.length !== sentence.numParts) {
+        this.multiPartBuffer.length = 0;
+        throw new DecodingError('Incorrect multipart order', sentence);
+      }
+
       const payloads = this.multiPartBuffer.map(
         multiPartSentence => multiPartSentence.payload
       );


### PR DESCRIPTION
* Resets the multi part buffer after a multipart message was processed
* Check if the multipartBuffer has the correct number of messages to decode otherwise ignore and throw error. In the aishub stream are some "single" multipart messages like in this sequence here for example:

```
partNumber, numParts, partId
1 2 4
2 2 4
1 2 9
2 2 9
1 2 9
2 2 9
1 2 0
2 2 0
1 2 0
2 2 0
2 2 6 <-- error
1 2 7
2 2 7
``` 

The strange thing is that the partId '6' was correct before with:
```
1 2 6
2 2 6
```